### PR TITLE
Load from css text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 .vscode/
 /demo/node_modules/
 /demo/platforms/
+/demo/package-lock.json
 *.tgz
 *.tar

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea/
+.vscode/
 /demo/node_modules/
 /demo/platforms/
 *.tgz

--- a/src/README.md
+++ b/src/README.md
@@ -1,9 +1,8 @@
-[![npm](https://img.shields.io/npm/v/nativescript-themes.svg)](https://www.npmjs.com/package/nativescript-themes)
-[![npm](https://img.shields.io/npm/l/nativescript-themes.svg)](https://www.npmjs.com/package/nativescript-themes)
-[![npm](https://img.shields.io/npm/dt/nativescript-themes.svg?label=npm%20d%2fls)](https://www.npmjs.com/package/nativescript-themes)
+[![npm](https://img.shields.io/npm/v/nativescript-themes.svg)](https://www.npmjs.com/package/nativescript-themes) [![npm](https://img.shields.io/npm/l/nativescript-themes.svg)](https://www.npmjs.com/package/nativescript-themes) [![npm](https://img.shields.io/npm/dt/nativescript-themes.svg?label=npm%20d%2fls)](https://www.npmjs.com/package/nativescript-themes)
 
 # nativescript-themes
-A NativeScript plugin to deal with dynamically loading UI Themes 
+
+A NativeScript plugin to deal with dynamically loading UI Themes
 
 ## Installation
 
@@ -15,14 +14,14 @@ tns plugin add nativescript-themes@1.1.0
 
 tns plugin add nativescript-themes
 
-
 ## Status: BROKEN in NS 3 & 4
-Please note this plugin is currently broken do to some new issues in the actual NativeScript core modules.  Until they fix either:
-- [https://github.com/NativeScript/NativeScript/issues/5912](https://github.com/NativeScript/NativeScript/issues/5912)
-- [https://github.com/NativeScript/NativeScript/issues/5911](https://github.com/NativeScript/NativeScript/issues/5911)
 
-This plugin will be unable to work....   Please up vote those issues if you want to see this plugin work again...
+Please note this plugin is currently broken do to some new issues in the actual NativeScript core modules. Until they fix either:
 
+-   [https://github.com/NativeScript/NativeScript/issues/5912](https://github.com/NativeScript/NativeScript/issues/5912)
+-   [https://github.com/NativeScript/NativeScript/issues/5911](https://github.com/NativeScript/NativeScript/issues/5911)
+
+This plugin will be unable to work.... Please up vote those issues if you want to see this plugin work again...
 
 ## License
 
@@ -30,81 +29,101 @@ This is released under the MIT License, meaning you are free to include this in 
 
 I also do contract work; so if you have a module you want built for NativeScript (or any other software projects) feel free to contact me [nathan@master-technology.com](mailto://nathan@master-technology.com).
 
-[![Donate](https://img.shields.io/badge/Donate-PayPal-brightgreen.svg?style=plastic)](https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=HN8DDMWVGBNQL&lc=US&item_name=Nathanael%20Anderson&item_number=nativescript%2dthemes&no_note=1&no_shipping=1&currency_code=USD&bn=PP%2dDonationsBF%3ax%3aNonHosted)
-[![Patreon](https://img.shields.io/badge/Pledge-Patreon-brightgreen.svg?style=plastic)](https://www.patreon.com/NathanaelA)
-
+[![Donate](https://img.shields.io/badge/Donate-PayPal-brightgreen.svg?style=plastic)](https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=HN8DDMWVGBNQL&lc=US&item_name=Nathanael%20Anderson&item_number=nativescript%2dthemes&no_note=1&no_shipping=1&currency_code=USD&bn=PP%2dDonationsBF%3ax%3aNonHosted) [![Patreon](https://img.shields.io/badge/Pledge-Patreon-brightgreen.svg?style=plastic)](https://www.patreon.com/NathanaelA)
 
 ## Sample Snapshot
+
 ![Sample1](docs/themes.gif)
-
-
 
 ## Usage
 
 To use the module you just `require()` it:
 
 ```js
-var themes = require( "nativescript-themes" );
+var themes = require("nativescript-themes");
 ```
 
 ## Setup in App
+
 Modify your startup app.js
 
 ```js
-var themes = require('nativescript-themes');
-themes.applyTheme(themes.getAppliedTheme('red-theme.css'));
+var themes = require("nativescript-themes");
+themes.applyTheme(themes.getAppliedTheme("red-theme.css"));
 ```
-This will automatically apply the "red-theme.css" theme if no other theme has ever been chosen as the default theme. 
 
+This will automatically apply the "red-theme.css" theme if no other theme has ever been chosen as the default theme.
 
+You can also load a theme bundled by webpack using `applyThemeCss`:
+
+```js
+var themes = require("nativescript-themes");
+var cssText = require("~/assets/themes/dark.scss");
+themes.applyThemeCss(cssText, "dark.scss");
+```
 
 ## You ask, how exactly does this help?
-This allows you to dynamically theme an application just by calling the theme system.  Your master app.css file is applied first, then the theme file and finally your page.css
+
+This allows you to dynamically theme an application just by calling the theme system. Your master app.css file is applied first, then the theme file and finally your page.css
 
 red-theme.css
+
 ```css
-Button {
-  background-color: red;
+button {
+    background-color: red;
 }
 ```
 
 green-theme.css
+
 ```css
-Button {
-  background-color: green;
+button {
+    background-color: green;
 }
 ```
 
 ## Demo
+
 Demo shows three sample themes, and shows how to load the last chosen theme at startup.
 
-
 ## Why use this?
+
 This allows you to apply a specific theme file globally so all pages get it.
 
-
 ### themes.applyTheme('cssFile', options);
+
 **options.noSave** = _true_, this will cause it not to save this info for the getAppliedTheme to retrieve, this would typically used if you needed temporarily apply a theme.
+
 ```js
-  var themes = require('nativescript-themes');
-  themes.applyTheme('red-theme.css');
+var themes = require("nativescript-themes");
+themes.applyTheme("red-theme.css");
 ```
 
-
 ### theme.getAppliedTheme(<default_theme>);
+
 This returns the last theme applied; if no theme has been applied it will use the default_theme.
+
 ```js
-  var themes = require('nativescript-themes');
-  var currentTheme = themes.getAppliedTheme('red-theme.css');
-  if (currentTheme === 'red-theme.css') {
-      console.log("We are using the default red-theme!")
-  } else {
-      console.log("We are using", currentTheme);
-  }
+var themes = require("nativescript-themes");
+var currentTheme = themes.getAppliedTheme("red-theme.css");
+if (currentTheme === "red-theme.css") {
+    console.log("We are using the default red-theme!");
+} else {
+    console.log("We are using", currentTheme);
+}
+```
+
+### themes.applyThemeCss('textCss', 'filename');
+
+This function receives a string containing CSS and applies it. The `filename` is only for reference (no file will be actually loaded).
+
+```js
+var themes = require("nativescript-themes");
+themes.applyThemeCss("page {background-color: black;}", "default-theme.css");
 ```
 
 ## Tutorials
 
-Need some extra help getting started?  Check out these tutorials for dealing with NativeScript UI themes in an iOS and Android application.
+Need some extra help getting started? Check out these tutorials for dealing with NativeScript UI themes in an iOS and Android application.
 
-* [Changing the UI Theme in a NativeScript Angular Application](https://www.thepolyglotdeveloper.com/2016/11/changing-a-nativescript-css-skin-at-runtime/)
+-   [Changing the UI Theme in a NativeScript Angular Application](https://www.thepolyglotdeveloper.com/2016/11/changing-a-nativescript-css-skin-at-runtime/)

--- a/src/themes.js
+++ b/src/themes.js
@@ -69,6 +69,10 @@ Themes.prototype.applyTheme = function(cssFile, options) {
     }
 };
 
+Themes.prototype.applyThemeCss = function(textCss, cssFileName) {
+    internalLoadCss(textCss, cssFileName);
+};
+
 function internalLoadCssFile(cssFile, path) {
     var FSA = new fsa();
     var cssFileName = cssFile;

--- a/src/themes.js
+++ b/src/themes.js
@@ -14,75 +14,62 @@
 
 var fs = require("file-system");
 var fsa = require("file-system/file-system-access").FileSystemAccess;
-var frameCommon = require('ui/frame/frame-common');
-var appSettings = require('application-settings');
-var application = require('application');
+var frameCommon = require("ui/frame/frame-common");
+var appSettings = require("application-settings");
+var application = require("application");
 //var styleScope = require('ui/styling/style-scope');
 
 // This allows some basic CSS to propogate properly from the frame; but not the localStyles CSS.  See bug NativeScript#5911 & #5912
 if (!frameCommon.FrameBase.prototype.eachChild) {
-	frameCommon.FrameBase.prototype.eachChild = frameCommon.FrameBase.prototype.eachChildView;
+    frameCommon.FrameBase.prototype.eachChild =
+        frameCommon.FrameBase.prototype.eachChildView;
 }
 
 var Themes = function() {
     this._curAppPath = fs.knownFolders.currentApp().path + "/";
 };
 
-
 Themes.prototype.getAppliedTheme = function(defaultTheme) {
-    defaultTheme = defaultTheme || '';
+    defaultTheme = defaultTheme || "";
 
-    if (appSettings.hasKey('__NS.themes')) {
-        var theme = appSettings.getString('__NS.themes', defaultTheme);
-        if (theme == null || theme === '') { return defaultTheme; }
+    if (appSettings.hasKey("__NS.themes")) {
+        var theme = appSettings.getString("__NS.themes", defaultTheme);
+        if (theme == null || theme === "") {
+            return defaultTheme;
+        }
         return theme;
     }
     return defaultTheme;
 };
 
-
-
 Themes.prototype.applyTheme = function(cssFile, options) {
-    if (!cssFile) { console.log("No Theme css file provided");  return; }
+    if (!cssFile) {
+        console.log("No Theme css file provided");
+        return;
+    }
     if (!application.hasLaunched() || !frameCommon.topmost()) {
+        var self = this;
+        var applyTheme = function() {
+            console.log("Delayed Load");
+            internalLoadCssFile(cssFile, self._curAppPath);
+            if (!(options && options.noSave)) {
+                appSettings.setString("__NS.themes", cssFile);
+            }
+            application.off("loadAppCss", applyTheme);
+        };
 
-    	var self = this;
-    	var applyTheme =  function() {
-    		console.log("Delayed Load");
-    		internalLoadCss(cssFile, self._curAppPath);
-			if (!(options && options.noSave)) {
-				appSettings.setString('__NS.themes', cssFile);
-			}
-			application.off("loadAppCss", applyTheme);
-		};
+        application.on("loadAppCss", applyTheme);
+        return;
+    }
 
-		 application.on("loadAppCss", applyTheme);
-		 return;
-	}
-
-	console.log("Immediate Load");
-    internalLoadCss(cssFile, this._curAppPath);
+    console.log("Immediate Load");
+    internalLoadCssFile(cssFile, this._curAppPath);
     if (!(options && options.noSave)) {
-        appSettings.setString('__NS.themes', cssFile);
+        appSettings.setString("__NS.themes", cssFile);
     }
 };
 
-/**
- * Set the  theme .css file
- * @param cssFile - css file to load
- * @param path - application path
- */
-function internalLoadCss(cssFile, path) {
-
-	// If a Frame hasn't been loaded yet, delay some more...
-	var frame = frameCommon.topmost();
-	if (!frame) {
-		setTimeout(function() {
-			internalLoadCss(cssFile, path);
-		}, 50);
-		return;
-	}
-
+function internalLoadCssFile(cssFile, path) {
     var FSA = new fsa();
     var cssFileName = cssFile;
 
@@ -96,83 +83,109 @@ function internalLoadCss(cssFile, path) {
         cssFileName = fs.path.join(path, cssFileName);
     }
 
-    // TODO: Check and run a test to see if we need to look at the entire frame stack and adjust each frame's CSS...
-	// Notes: We can tie this to the currentPage and everything looks good for that page...  But we need this globally.
-    //
-	// One possible solution; We might be able to manually load the app.css file ourselves and merge it with the new theme css file.
-	//    However, this will leave the side effect of loosing any other appended css that they might have added outside of this plugin...
-	//
+    var textCSS = "";
 
-    var changed = false, preLoaded = false;
+    if (cssFileName && FSA.fileExists(cssFileName)) {
+        var file = fs.File.fromPath(cssFileName);
+        textCSS = file.readTextSync();
+    }
+
+    internalLoadCss(textCSS, cssFileName);
+}
+
+/**
+ * Set the  theme .css file
+ * @param cssFile - css file to load
+ * @param path - application path
+ */
+function internalLoadCss(textCss, cssFileName) {
+    // If a Frame hasn't been loaded yet, delay some more...
+    var frame = frameCommon.topmost();
+    if (!frame) {
+        setTimeout(function() {
+            internalLoadCss(textCss, cssFileName);
+        }, 50);
+        return;
+    }
+
+    // TODO: Check and run a test to see if we need to look at the entire frame stack and adjust each frame's CSS...
+    // Notes: We can tie this to the currentPage and everything looks good for that page...  But we need this globally.
+    //
+    // One possible solution; We might be able to manually load the app.css file ourselves and merge it with the new theme css file.
+    //    However, this will leave the side effect of loosing any other appended css that they might have added outside of this plugin...
+    //
+
+    var changed = false,
+        preLoaded = false;
     var styleScope = frame._styleScope;
     var curSelectors = styleScope._localCssSelectors;
-	// Clear the old Selectors out
-    for (var i=0;i<curSelectors.length;i++) {
-    	// Check to see if we have already loaded a theme, if so we need to remove it
-        if (curSelectors[i]._themeFile ) {
-        	// Is that a different theme?
-            if (curSelectors[i]._themeFile && curSelectors[i]._themeFile !== cssFileName) {
+    // Clear the old Selectors out
+    for (var i = 0; i < curSelectors.length; i++) {
+        // Check to see if we have already loaded a theme, if so we need to remove it
+        if (curSelectors[i]._themeFile) {
+            // Is that a different theme?
+            if (
+                curSelectors[i]._themeFile &&
+                curSelectors[i]._themeFile !== cssFileName
+            ) {
                 changed = true;
                 curSelectors.splice(i, 1);
                 i--;
             } else {
-            	// Nope, it is a rule from this theme...
+                // Nope, it is a rule from this theme...
                 preLoaded = true;
                 break;
             }
         }
     }
 
-	var cssLength = styleScope._css.length;
+    var cssLength = styleScope._css.length;
     if (!preLoaded) {
-    	// Load the new Selectors
-        if (cssFileName && FSA.fileExists(cssFileName)) {
-            var file = fs.File.fromPath(cssFileName);
-            var textCSS = file.readTextSync();
-			var cnt = curSelectors.length;
-            if (textCSS) {
-				styleScope.appendCss("/* +NS-THEME-MT */ "+ textCSS +" /* -NS-THEME-MT */", cssFileName);
-            }
-
-            var newCnt = curSelectors.length;
-            // If we fail to load the file, then we will treat it as if we had already loaded it
-            if (cnt === newCnt) {
-                preLoaded = true;
-            } else {
-            	for (var i=cnt;i<newCnt;i++) {
-            		curSelectors[i]._themeFile = cssFileName;
-				}
-			}
+        // Load the new Selectors
+        var cnt = curSelectors.length;
+        if (textCss) {
+            styleScope.appendCss(
+                "/* +NS-THEME-MT */ " + textCss + " /* -NS-THEME-MT */",
+                cssFileName
+            );
         }
 
+        var newCnt = curSelectors.length;
+        // If we fail to load the file, then we will treat it as if we had already loaded it
+        if (cnt === newCnt) {
+            preLoaded = true;
+        } else {
+            for (var i = cnt; i < newCnt; i++) {
+                curSelectors[i]._themeFile = cssFileName;
+            }
+        }
     }
 
     // If anything changed; then we need to trigger a change...
     if (changed || !preLoaded) {
+        /* First delete the old text version of the css to keep everything in sync */
+        var css = styleScope._css;
+        var start = css.indexOf("/* +NS-THEME-MT */");
+        var end = css.indexOf("/* -NS-THEME-MT */", start);
+        // Make sure we aren't deleting our newly added css  ;-)
+        if (start > -1 && end > -1 && start < cssLength) {
+            if (start > 0 && end < css.length) {
+                css =
+                    css.substring(0, start) +
+                    css.substring(end + 18, css.length);
+            } else if (start > 0) {
+                css = css.substring(0, start);
+            } else {
+                css = css.substring(end + 18, css.length);
+            }
+            styleScope._css = css;
+        }
 
-    	/* First delete the old text version of the css to keep everything in sync */
-    	var css = styleScope._css;
-    	var start = css.indexOf("/* +NS-THEME-MT */");
-    	var end = css.indexOf("/* -NS-THEME-MT */", start);
-    	// Make sure we aren't deleting our newly added css  ;-)
-    	if (start > -1 && end > -1 && start < cssLength) {
-			if (start > 0 && end < css.length) {
-				css = css.substring(0, start) + css.substring(end+18, css.length);
-			} else if (start > 0) {
-				css = css.substring(0, start);
-			} else {
-				css = css.substring(end+18, css.length);
-			}
-			styleScope._css = css;
-		}
-
-		// Trigger a Re-sync
-		styleScope._localCssSelectorVersion++;
-		styleScope.ensureSelectors();
-		frame._onCssStateChange();
-
-	}
-
+        // Trigger a Re-sync
+        styleScope._localCssSelectorVersion++;
+        styleScope.ensureSelectors();
+        frame._onCssStateChange();
+    }
 }
 
 // Export the theme system


### PR DESCRIPTION
This PR adds the function `applyThemeCss` that receives a string containing CSS and applies it.

The branch was created from commit e04f0a937a223363828a99b0bf45616d68529670 (the version published in npm) because the code in master didn't work.

I created the sample project [ns-vue-theme-swap-sample](https://github.com/tralves/ns-vue-theme-swap-sample). In this project, I implemented theme swapping with both the existing method `applyTheme` and the new method `applyThemeCss` to show that I didn't ruin the current functionality.

The file `themes.js` had both tabs and spaces, so I went ahead an prettyfied it... sorry...