### PR TITLE
2.0.0 load from css text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@
 /demo/platforms/
 *.tgz
 *.tar
+node_modules
+hooks
+platforms
+*.DS_Store 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,108 @@
 # NativeScript-Themes
 
+A NativeScript plugin to deal with dynamically loading UI Themes
 
 ## Developed by
+
 [![MasterTech](https://plugins.nativescript.rocks/i/mtns.png)](https://plugins.nativescript.rocks/mastertech-nstudio)
 
+[![npm](https://img.shields.io/npm/v/nativescript-themes.svg)](https://www.npmjs.com/package/nativescript-themes)
+[![npm](https://img.shields.io/npm/l/nativescript-themes.svg)](https://www.npmjs.com/package/nativescript-themes)
+[![npm](https://img.shields.io/npm/dt/nativescript-themes.svg?label=npm%20d%2fls)](https://www.npmjs.com/package/nativescript-themes)
 
+## Installation
 
-## Documentation
-The [documentation](src/README.md) for the plugin is located in the [src folder](src).
+tns plugin add nativescript-themes
+
+## Sample Snapshot
+
+![Sample1](docs/themes.gif)
+
+## Usage
+
+To use the module `require()` it:
+
+```js
+var themes = require('nativescript-themes');
+```
+
+## Setup in App
+
+Modify the entry point of your application, usually app.js
+
+```js
+var themes = require('nativescript-themes');
+themes.applyTheme(themes.getAppliedTheme('red-theme.css'));
+```
+
+This will automatically apply the "red-theme.css" theme if no other theme has ever been chosen as the default theme.
+
+## You ask, how exactly does this help?
+
+This allows you to dynamically theme an application just by calling the theme system. Your app.css file is applied first, then the theme file and finally your page.css
+
+red-theme.css
+
+```css
+button {
+	background-color: red;
+}
+```
+
+green-theme.css
+
+```css
+button {
+	background-color: green;
+}
+```
+
+## Demo
+
+Demo shows three sample themes, and shows how to load the last chosen theme at startup.
+
+## Why use this?
+
+This allows you to apply a specific theme file globally so all pages get it.
+
+### themes.applyTheme('cssFile', options);
+
+**options.noSave** = _true_, this will cause it not to save this info for the getAppliedTheme to retrieve, this would typically used if you needed temporarily apply a theme.
+
+```js
+var themes = require('nativescript-themes');
+themes.applyTheme('red-theme.css');
+```
+
+### theme.getAppliedTheme(<default_theme>);
+
+This returns the last theme applied; if no theme has been applied it will use the default_theme.
+
+```js
+var themes = require('nativescript-themes');
+var currentTheme = themes.getAppliedTheme('red-theme.css');
+if (currentTheme === 'red-theme.css') {
+	console.log('We are using the default red-theme!');
+} else {
+	console.log('We are using', currentTheme);
+}
+```
+
+### Important
+
+Be careful declaring your app styles in the main `app.css` file. Those styles take precedent over the themes. So if you plan to use a theming approach in your application, it's best to keep the `app.css` to a minimum of styles that are shared possibly between your themes.
+
+## Tutorials
+
+Need some extra help getting started? Check out these tutorials for dealing with NativeScript UI themes in an iOS and Android application.
+
+- [Changing the UI Theme in a NativeScript Angular Application](https://www.thepolyglotdeveloper.com/2016/11/changing-a-nativescript-css-skin-at-runtime/)
+
+## License
+
+This is released under the MIT License, meaning you are free to include this in any type of program -- However for entities that need a support contract, changes, enhancements and/or a commercial license please contact me at [http://nativescript.tools](http://nativescript.tools).
+
+I also do contract work; so if you have a module you want built for NativeScript (or any other software projects) feel free to contact me [nathan@master-technology.com](mailto://nathan@master-technology.com).
+
+[![Donate](https://img.shields.io/badge/Donate-PayPal-brightgreen.svg?style=plastic)](https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=HN8DDMWVGBNQL&lc=US&item_name=Nathanael%20Anderson&item_number=nativescript%2dthemes&no_note=1&no_shipping=1&currency_code=USD&bn=PP%2dDonationsBF%3ax%3aNonHosted)
+[![Patreon](https://img.shields.io/badge/Pledge-Patreon-brightgreen.svg?style=plastic)](https://www.patreon.com/NathanaelA)

--- a/demo/.editorconfig
+++ b/demo/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+
+[*.json]
+indent_style = space
+indent_size = 2
+
+[*.js]
+indent_style = space
+indent_size = 4

--- a/demo/.gitignore
+++ b/demo/.gitignore
@@ -1,0 +1,31 @@
+# NativeScript
+hooks/
+node_modules/
+platforms/
+
+# NativeScript Template
+*.js.map
+
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+.idea
+.cloud
+.project
+tmp/
+typings/
+
+# Visual Studio Code
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json

--- a/demo/LICENSE
+++ b/demo/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright (c) 2015-2019 Progress Software Corporation
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/demo/app/App_Resources/Android/app.gradle
+++ b/demo/app/App_Resources/Android/app.gradle
@@ -2,22 +2,19 @@
 
 // Uncomment to add recyclerview-v7 dependency
 //dependencies {
-//	compile 'com.android.support:recyclerview-v7:+'
+//	implementation 'com.android.support:recyclerview-v7:+'
 //}
 
-android {  
-  defaultConfig {  
+// If you want to add something to be applied before applying plugins' include.gradle files
+// e.g. project.ext.googlePlayServicesVersion = "15.0.1"
+// create a file named before-plugins.gradle in the current directory and place it there
+
+android {
+  defaultConfig {
+    minSdkVersion 17
     generatedDensities = []
-    applicationId = "org.nativescript.demo" 
-    
-    //override supported platforms
-    // ndk {
-    //       abiFilters.clear()
-    //   		abiFilters "armeabi-v7a"
- 		// }
-  
-  }  
-  aaptOptions {  
-    additionalParameters "--no-version-vectors"  
-  }  
-} 
+  }
+  aaptOptions {
+    additionalParameters "--no-version-vectors"
+  }
+}

--- a/demo/app/App_Resources/Android/src/main/AndroidManifest.xml
+++ b/demo/app/App_Resources/Android/src/main/AndroidManifest.xml
@@ -10,10 +10,6 @@
 		android:largeScreens="true"
 		android:xlargeScreens="true"/>
 
-	<uses-sdk
-		android:minSdkVersion="17"
-		android:targetSdkVersion="__APILEVEL__"/>
-
 	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 	<uses-permission android:name="android.permission.INTERNET"/>
@@ -28,7 +24,7 @@
 		<activity
 			android:name="com.tns.NativeScriptActivity"
 			android:label="@string/title_activity_kimera"
-			android:configChanges="keyboardHidden|orientation|screenSize"
+			android:configChanges="keyboard|keyboardHidden|orientation|screenSize|smallestScreenSize|screenLayout|locale|uiMode"
 			android:theme="@style/LaunchScreenTheme">
 
 			<meta-data android:name="SET_THEME_ON_LAUNCH" android:resource="@style/AppTheme" />

--- a/demo/app/app.css
+++ b/demo/app/app.css
@@ -1,24 +1,5 @@
-﻿/*
-In NativeScript, the app.css file is where you place CSS rules that
-you would like to apply to your entire application. Check out
-http://docs.nativescript.org/ui/styling for a full list of the CSS
-selectors and properties you can use to style UI components.
+﻿@import '~nativescript-theme-core/css/core.light.css';
 
-/*
-In many cases you may want to use the NativeScript core theme instead
-of writing your own CSS rules. For a full list of class names in the theme
-refer to http://docs.nativescript.org/ui/theme.
-The imported CSS rules must precede all other types of rules.
-*/
-@import '~nativescript-theme-core/css/core.light.css';
-
-/* Page {
-    background-color: transparent;
-} */
-/*
-The following CSS rule changes the font size of all UI
-components that have the btn class name.
-*/
 .title {
-    font-family: monospace;
+	font-family: monospace;
 }

--- a/demo/app/app.js
+++ b/demo/app/app.js
@@ -4,13 +4,12 @@ You can use this file to perform app-level initialization, but the primary
 purpose of the file is to pass control to the app’s first module.
 */
 
-require("./bundle-config");
-var application = require("application");
+const application = require('tns-core-modules/application');
 
-var themes = require('nativescript-themes');
+const themes = require('nativescript-themes');
 themes.applyTheme(themes.getAppliedTheme('light.css'));
 
-application.run({ moduleName: "app-root" });
+application.run({ moduleName: 'app-root' });
 
 /*
 Do not place any code after the application has been started as it will not

--- a/demo/app/blue.css
+++ b/demo/app/blue.css
@@ -1,32 +1,32 @@
 .title {
-    font-size: 30;
-    horizontal-align: center;
-    margin: 20;
+	font-size: 30;
+	horizontal-align: center;
+	margin: 20;
 }
 
 button {
-    font-size: 26;
-    horizontal-align: center;
+	font-size: 26;
+	horizontal-align: center;
 }
 
 .message {
-    font-size: 20;
-    color: lightgoldenrodyellow;
-    horizontal-align: center;
-    margin: 0 20;
-    text-align: center;
+	font-size: 20;
+	color: lightgoldenrodyellow;
+	horizontal-align: center;
+	margin: 0 20;
+	text-align: center;
 }
 
 Page {
-    background-color: blue;
-    color: antiquewhite;
+	background-color: blue;
+	color: antiquewhite;
 }
 
 ActionBar {
-    color: white;
-    background-color: blue;
+	color: white;
+	background-color: blue;
 }
 
 .blue {
-    color: blue;
+	color: blue;
 }

--- a/demo/app/dark.css
+++ b/demo/app/dark.css
@@ -1,32 +1,32 @@
-﻿.title {
-    font-size: 30;
-    horizontal-align: center;
-    margin: 20;
+.title {
+	font-size: 30;
+	horizontal-align: center;
+	margin: 20;
 }
 
 button {
-    font-size: 38;
-    horizontal-align: center;
+	font-size: 38;
+	horizontal-align: center;
 }
 
 .message {
-    font-size: 20;
-    color: lightgoldenrodyellow;
-    horizontal-align: center;
-    margin: 0 20;
-    text-align: center;
+	font-size: 20;
+	color: lightgoldenrodyellow;
+	horizontal-align: center;
+	margin: 0 20;
+	text-align: center;
 }
 
 Page {
-    background-color: #284848;
-    color: antiquewhite;
+	background-color: #284848;
+	color: antiquewhite;
 }
 
-ActionBar{
-    color: brown;
-    background-color: black;
+ActionBar {
+	color: brown;
+	background-color: black;
 }
 
 .dark {
-    color: black;
+	color: black;
 }

--- a/demo/app/light.css
+++ b/demo/app/light.css
@@ -1,32 +1,32 @@
-﻿.title {
-    font-size: 30;
-    horizontal-align: center;
-    margin: 20;
+.title {
+	font-size: 30;
+	horizontal-align: center;
+	margin: 20;
 }
 
 button {
-    font-size: 32;
-    horizontal-align: center;
+	font-size: 32;
+	horizontal-align: center;
 }
 
 .message {
-    font-size: 20;
-    color: #284848;
-    horizontal-align: center;
-    margin: 0 20;
-    text-align: center;
+	font-size: 20;
+	color: #284848;
+	horizontal-align: center;
+	margin: 0 20;
+	text-align: center;
 }
 
 Page {
-    background-color: white;
-    color: black;
+	background-color: white;
+	color: black;
 }
 
 ActionBar {
-    color: white;
-    background-color: purple;
+	color: white;
+	background-color: purple;
 }
 
 .light {
-    color: white;
+	color: white;
 }

--- a/demo/app/main-page.js
+++ b/demo/app/main-page.js
@@ -1,49 +1,13 @@
-/*
-In NativeScript, a file with the same name as an XML file is known as
-a code-behind file. The code-behind is a great place to place your view
-logic, and to set up your page’s data binding.
-*/
-
-/*
-NativeScript adheres to the CommonJS specification for dealing with
-JavaScript modules. The CommonJS require() function is how you import
-JavaScript modules defined in other files.
-*/
-var createViewModel = require("./main-view-model").createViewModel;
+var createViewModel = require('./main-view-model').createViewModel;
 
 function onNavigatingTo(args) {
-    /*
-    This gets a reference this page’s <Page> UI component. You can
-    view the API reference of the Page to see what’s available at
-    https://docs.nativescript.org/api-reference/classes/_ui_page_.page.html
-    */
-    var page = args.object;
-
-    /*
-    A page’s bindingContext is an object that should be used to perform
-    data binding between XML markup and JavaScript code. Properties
-    on the bindingContext can be accessed using the {{ }} syntax in XML.
-    In this example, the {{ message }} and {{ onTap }} bindings are resolved
-    against the object returned by createViewModel().
-
-    You can learn more about data binding in NativeScript at
-    https://docs.nativescript.org/core-concepts/data-binding.
-    */
-    page.bindingContext = createViewModel();
+	var page = args.object;
+	page.bindingContext = createViewModel();
 }
-
-/*
-Exporting a function in a NativeScript code-behind file makes it accessible
-to the file’s corresponding XML file. In this case, exporting the onNavigatingTo
-function here makes the navigatingTo="onNavigatingTo" binding in this page’s XML
-file work.
-*/
 exports.onNavigatingTo = onNavigatingTo;
 
-
-
 exports.secondpage = function() {
-	var frame = require('ui/frame');
+	var frame = require('tns-core-modules/ui/frame');
 	//frame.topmost().currentPage.addCss("Button { background-color: green; color: purple; }");
 	frame.topmost().navigate('second-page');
 };

--- a/demo/app/main-page.xml
+++ b/demo/app/main-page.xml
@@ -9,6 +9,6 @@
         <Label row="2" text=""/>
         <Label row="3" text="{{ message }}" class="message" textWrap="true" tap="secondpage"/>
 
-    <HtmlView row="4" colSpan="2"  html="&lt;a href='http://www.master-technology.com'&gt;(c)2015-2018, Master Technology&lt;/a&gt;" class="copyright"/>
+        <HtmlView row="4" colSpan="2" html="&lt;a href='http://www.master-technology.com'&gt;(c)2015-2018, Master Technology&lt;/a&gt;" class="copyright"/>
     </GridLayout>
 </Page>

--- a/demo/app/main-view-model.js
+++ b/demo/app/main-view-model.js
@@ -1,51 +1,49 @@
-var Observable = require("data/observable").Observable;
+var Observable = require('tns-core-modules/data/observable').Observable;
 var themes = require('nativescript-themes');
-
 
 function getMessage(counter) {
 	var themeId = counter % 3;
-	if (themeId  === 0) {
-		return "Current theme is: Light";
+	if (themeId === 0) {
+		return 'Current theme is: Light';
 	} else if (themeId === 1) {
-		return "Current theme is: Dark";
+		return 'Current theme is: Dark';
 	} else {
-		return "Current theme is Blue";
+		return 'Current theme is Blue';
 	}
-
 }
+
 function getNextTheme(counter) {
 	var themeId = counter % 3;
-	if (themeId  === 0) {
-		return "Click for Dark theme";
+	if (themeId === 0) {
+		return 'Click for Dark theme';
 	} else if (themeId === 1) {
-		return "Click for Blue theme";
+		return 'Click for Blue theme';
 	} else {
-		return "Click for Light theme";
+		return 'Click for Light theme';
 	}
-
 }
-
 
 function createViewModel() {
 	var viewModel = new Observable();
 	viewModel.curTheme = 0;
 	var curThemeName = themes.getAppliedTheme('light.css');
-	if (curThemeName === 'dark.css') { viewModel.curTheme++; }
-	else if (curThemeName === 'blue.css') { viewModel.curTheme += 2; }
+	if (curThemeName === 'dark.css') {
+		viewModel.curTheme++;
+	} else if (curThemeName === 'blue.css') {
+		viewModel.curTheme += 2;
+	}
 
 	viewModel.message = getMessage(viewModel.curTheme);
 	viewModel.nextTheme = getNextTheme(viewModel.curTheme);
 
-
-
 	viewModel.onTap = function() {
 		this.curTheme++;
-		this.set("message", getMessage(this.curTheme));
-		this.set("nextTheme", getNextTheme(this.curTheme));
+		this.set('message', getMessage(this.curTheme));
+		this.set('nextTheme', getNextTheme(this.curTheme));
 
 		var themeId = this.curTheme % 3;
 
-		switch( themeId ) {
+		switch (themeId) {
 			case 0:
 				themes.applyTheme('light.css');
 				break;
@@ -56,10 +54,6 @@ function createViewModel() {
 				themes.applyTheme('blue.css');
 				break;
 		}
-
-
-
-
 	};
 
 	return viewModel;

--- a/demo/app/package.json
+++ b/demo/app/package.json
@@ -1,8 +1,6 @@
 {
+  "main": "app.js",
   "android": {
     "v8Flags": "--expose_gc"
-  },
-  "main": "app.js",
-  "name": "tns-template-hello-world",
-  "version": "4.1.0"
+  }
 }

--- a/demo/app/second-page.js
+++ b/demo/app/second-page.js
@@ -1,18 +1,11 @@
-
 var themes = require('nativescript-themes');
 
 exports.click = function() {
-    themes.applyTheme('dark.css');
+	themes.applyTheme('dark.css');
 };
 
-exports.loaded = function() {
+exports.loaded = function() {};
 
-};
+exports.navigatedTo = function() {};
 
-exports.navigatedTo = function() {
-
-};
-
-exports.navigatingTo = function() {
-
-};
+exports.navigatingTo = function() {};

--- a/demo/jsconfig.json
+++ b/demo/jsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "baseUrl": "./",
+    "paths": {
+      "*": ["./node_modules/tns-core-modules/*", "./node_modules/*"],
+      "~/*": ["app/*"]
+    }
+  },
+  "include": ["app/**/*"]
+}

--- a/demo/package.json
+++ b/demo/package.json
@@ -1,23 +1,21 @@
 {
-	"description": "NativeScript Application",
-	"license": "SEE LICENSE IN <your-license-filename>",
-	"readme": "NativeScript Application",
-	"repository": "<fill-your-repository-here>",
 	"nativescript": {
-		"id": "org.nativescript.demo",
+		"id": "org.nativescript.tp",
 		"tns-android": {
-			"version": "4.1.1"
+			"version": "5.3.0"
 		}
 	},
+	"description": "NativeScript Application",
+	"license": "SEE LICENSE IN <your-license-filename>",
+	"repository": "<fill-your-repository-here>",
 	"dependencies": {
 		"nativescript-theme-core": "~1.0.4",
-		"nativescript-themes": "file:..\\src",
-		"tns-core-modules": "~4.1.0"
+		"tns-core-modules": "~5.3.1",
+		"nativescript-themes": "file:../src"
 	},
 	"devDependencies": {
-		"babel-traverse": "6.4.5",
-		"babel-types": "6.4.5",
-		"babylon": "6.4.5",
-		"lazy": "1.0.11"
-	}
+		"nativescript-dev-webpack": "~0.21.0"
+	},
+	"gitHead": "c175016cf900d406d2428bb6c4fcbb62093fb351",
+	"readme": "NativeScript Application"
 }

--- a/demo/webpack.config.js
+++ b/demo/webpack.config.js
@@ -1,0 +1,274 @@
+const { join, relative, resolve, sep } = require("path");
+
+const webpack = require("webpack");
+const nsWebpack = require("nativescript-dev-webpack");
+const nativescriptTarget = require("nativescript-dev-webpack/nativescript-target");
+const CleanWebpackPlugin = require("clean-webpack-plugin");
+const CopyWebpackPlugin = require("copy-webpack-plugin");
+const { BundleAnalyzerPlugin } = require("webpack-bundle-analyzer");
+const { NativeScriptWorkerPlugin } = require("nativescript-worker-loader/NativeScriptWorkerPlugin");
+const UglifyJsPlugin = require("uglifyjs-webpack-plugin");
+const hashSalt =  Date.now().toString();
+
+module.exports = env => {
+    // Add your custom Activities, Services and other android app components here.
+    const appComponents = [
+        "tns-core-modules/ui/frame",
+        "tns-core-modules/ui/frame/activity",
+    ];
+
+    const platform = env && (env.android && "android" || env.ios && "ios");
+    if (!platform) {
+        throw new Error("You need to provide a target platform!");
+    }
+
+    const platforms = ["ios", "android"];
+    const projectRoot = __dirname;
+
+    // Default destination inside platforms/<platform>/...
+    const dist = resolve(projectRoot, nsWebpack.getAppPath(platform, projectRoot));
+    const appResourcesPlatformDir = platform === "android" ? "Android" : "iOS";
+
+    const {
+        // The 'appPath' and 'appResourcesPath' values are fetched from
+        // the nsconfig.json configuration file
+        // when bundling with `tns run android|ios --bundle`.
+        appPath = "app",
+        appResourcesPath = "app/App_Resources",
+
+        // You can provide the following flags when running 'tns run android|ios'
+        snapshot, // --env.snapshot
+        uglify, // --env.uglify
+        report, // --env.report
+        sourceMap, // --env.sourceMap
+        hmr, // --env.hmr,
+        unitTesting, // --env.unitTesting
+    } = env;
+    const externals = nsWebpack.getConvertedExternals(env.externals);
+
+    const appFullPath = resolve(projectRoot, appPath);
+    const appResourcesFullPath = resolve(projectRoot, appResourcesPath);
+
+    const entryModule = nsWebpack.getEntryModule(appFullPath);
+    const entryPath = `.${sep}${entryModule}.js`;
+    const entries = { bundle: entryPath };
+    if (platform === "ios") {
+        entries["tns_modules/tns-core-modules/inspector_modules"] = "inspector_modules.js";
+    };
+
+    const config = {
+        mode: uglify ? "production" : "development",
+        context: appFullPath,
+        externals,
+        watchOptions: {
+            ignored: [
+                appResourcesFullPath,
+                // Don't watch hidden files
+                "**/.*",
+            ]
+        },
+        target: nativescriptTarget,
+        entry: entries,
+        output: {
+            pathinfo: false,
+            path: dist,
+            libraryTarget: "commonjs2",
+            filename: "[name].js",
+            globalObject: "global",
+            hashSalt
+        },
+        resolve: {
+            extensions: [".js", ".scss", ".css"],
+            // Resolve {N} system modules from tns-core-modules
+            modules: [
+                "node_modules/tns-core-modules",
+                "node_modules",
+            ],
+            alias: {
+                '~': appFullPath
+            },
+            // don't resolve symlinks to symlinked modules
+            symlinks: false
+        },
+        resolveLoader: {
+            // don't resolve symlinks to symlinked loaders
+            symlinks: false
+        },
+        node: {
+            // Disable node shims that conflict with NativeScript
+            "http": false,
+            "timers": false,
+            "setImmediate": false,
+            "fs": "empty",
+            "__dirname": false,
+        },
+        devtool: sourceMap ? "inline-source-map" : "none",
+        optimization: {
+            runtimeChunk: "single",
+            splitChunks: {
+                cacheGroups: {
+                    vendor: {
+                        name: "vendor",
+                        chunks: "all",
+                        test: (module, chunks) => {
+                            const moduleName = module.nameForCondition ? module.nameForCondition() : '';
+                            return /[\\/]node_modules[\\/]/.test(moduleName) ||
+                                    appComponents.some(comp => comp === moduleName);
+
+                        },
+                        enforce: true,
+                    },
+                }
+            },
+            minimize: !!uglify,
+            minimizer: [
+                new UglifyJsPlugin({
+                    parallel: true,
+                    cache: true,
+                    uglifyOptions: {
+                        output: {
+                            comments: false,
+                        },
+                        compress: {
+                            // The Android SBG has problems parsing the output
+                            // when these options are enabled
+                            'collapse_vars': platform !== "android",
+                            sequences: platform !== "android",
+                        }
+                    }
+                })
+            ],
+        },
+        module: {
+            rules: [
+                {
+                    test: nsWebpack.getEntryPathRegExp(appFullPath, entryPath),
+                    use: [
+                        // Require all Android app components
+                        platform === "android" && {
+                            loader: "nativescript-dev-webpack/android-app-components-loader",
+                            options: { modules: appComponents }
+                        },
+
+                        {
+                            loader: "nativescript-dev-webpack/bundle-config-loader",
+                            options: {
+                                loadCss: !snapshot, // load the application css if in debug mode
+                                unitTesting,
+                                appFullPath,
+                                projectRoot,
+                            }
+                        },
+                    ].filter(loader => !!loader)
+                },
+
+                {
+                    test: /-page\.js$/,
+                    use: "nativescript-dev-webpack/script-hot-loader"
+                },
+
+                {
+                    test: /\.(css|scss)$/,
+                    use: "nativescript-dev-webpack/style-hot-loader"
+                },
+
+                {
+                    test: /\.(html|xml)$/,
+                    use: "nativescript-dev-webpack/markup-hot-loader"
+                },
+
+                { test: /\.(html|xml)$/, use: "nativescript-dev-webpack/xml-namespace-loader"},
+
+                {
+                    test: /\.css$/,
+                    use: { loader: "css-loader", options: { minimize: false, url: false } }
+                },
+
+                {
+                    test: /\.scss$/,
+                    use: [
+                        { loader: "css-loader", options: { minimize: false, url: false } },
+                        "sass-loader"
+                    ]
+                },
+            ]
+        },
+        plugins: [
+            // Define useful constants like TNS_WEBPACK
+            new webpack.DefinePlugin({
+                "global.TNS_WEBPACK": "true",
+                "process": undefined,
+            }),
+            // Remove all files from the out dir.
+            new CleanWebpackPlugin([ `${dist}/**/*` ]),
+            // Copy assets to out dir. Add your own globs as needed.
+            new CopyWebpackPlugin([
+                { from: { glob: "fonts/**" } },
+                { from: { glob: "**/*.css" } },
+                { from: { glob: "**/*.jpg" } },
+                { from: { glob: "**/*.png" } },
+            ], { ignore: [`${relative(appPath, appResourcesFullPath)}/**`] }),
+            // Generate a bundle starter script and activate it in package.json
+            new nsWebpack.GenerateBundleStarterPlugin(
+                // Don't include `runtime.js` when creating a snapshot. The plugin
+                // configures the WebPack runtime to be generated inside the snapshot
+                // module and no `runtime.js` module exist.
+                (snapshot ? [] : ["./runtime"])
+                .concat([
+                    "./vendor",
+                    "./bundle",
+              ])
+            ),
+            // For instructions on how to set up workers with webpack
+            // check out https://github.com/nativescript/worker-loader
+            new NativeScriptWorkerPlugin(),
+            new nsWebpack.PlatformFSPlugin({
+                platform,
+                platforms,
+            }),
+            // Does IPC communication with the {N} CLI to notify events when running in watch mode.
+            new nsWebpack.WatchStateLoggerPlugin(),
+        ],
+    };
+
+    // Copy the native app resources to the out dir
+    // only if doing a full build (tns run/build) and not previewing (tns preview)
+    if (!externals || externals.length === 0) {
+        config.plugins.push(new CopyWebpackPlugin([
+            {
+                from: `${appResourcesFullPath}/${appResourcesPlatformDir}`,
+                to: `${dist}/App_Resources/${appResourcesPlatformDir}`,
+                context: projectRoot
+            },
+        ]));
+    }
+
+    if (report) {
+        // Generate report files for bundles content
+        config.plugins.push(new BundleAnalyzerPlugin({
+            analyzerMode: "static",
+            openAnalyzer: false,
+            generateStatsFile: true,
+            reportFilename: resolve(projectRoot, "report", `report.html`),
+            statsFilename: resolve(projectRoot, "report", `stats.json`),
+        }));
+    }
+
+    if (snapshot) {
+        config.plugins.push(new nsWebpack.NativeScriptSnapshotPlugin({
+            chunk: "vendor",
+            requireModules: [
+                "tns-core-modules/bundle-entry-points",
+            ],
+            projectRoot,
+            webpackConfig: config,
+        }));
+    }
+
+    if (hmr) {
+        config.plugins.push(new webpack.HotModuleReplacementPlugin());
+    }
+
+
+    return config;
+};

--- a/src/.npmignore
+++ b/src/.npmignore
@@ -6,3 +6,4 @@ docs/
 .npmignore
 *.tgz
 *.tar
+node_modules

--- a/src/README.md
+++ b/src/README.md
@@ -18,8 +18,8 @@ tns plugin add nativescript-themes
 
 Please note this plugin is currently broken do to some new issues in the actual NativeScript core modules. Until they fix either:
 
-- [https://github.com/NativeScript/NativeScript/issues/5912](https://github.com/NativeScript/NativeScript/issues/5912)
-- [https://github.com/NativeScript/NativeScript/issues/5911](https://github.com/NativeScript/NativeScript/issues/5911)
+-   [https://github.com/NativeScript/NativeScript/issues/5912](https://github.com/NativeScript/NativeScript/issues/5912)
+-   [https://github.com/NativeScript/NativeScript/issues/5911](https://github.com/NativeScript/NativeScript/issues/5911)
 
 This plugin will be unable to work.... Please up vote those issues if you want to see this plugin work again...
 
@@ -40,7 +40,7 @@ I also do contract work; so if you have a module you want built for NativeScript
 To use the module you just `require()` it:
 
 ```js
-var themes = require('nativescript-themes')
+var themes = require('nativescript-themes');
 ```
 
 ## Setup in App
@@ -48,8 +48,8 @@ var themes = require('nativescript-themes')
 Modify your startup app.js
 
 ```js
-var themes = require('nativescript-themes')
-themes.applyTheme(themes.getAppliedTheme('red-theme.css'))
+var themes = require('nativescript-themes');
+themes.applyTheme(themes.getAppliedTheme('red-theme.css'));
 ```
 
 This will automatically apply the "red-theme.css" theme if no other theme has ever been chosen as the default theme.
@@ -57,9 +57,9 @@ This will automatically apply the "red-theme.css" theme if no other theme has ev
 You can also load a theme bundled by webpack using `applyThemeCss`:
 
 ```js
-var themes = require('nativescript-themes')
-var cssText = require('~/assets/themes/dark.scss')
-themes.applyThemeCss(cssText, 'dark.scss')
+var themes = require('nativescript-themes');
+var cssText = require('~/assets/themes/dark.scss');
+themes.applyThemeCss(cssText, 'dark.scss');
 ```
 
 ## You ask, how exactly does this help?
@@ -70,7 +70,7 @@ red-theme.css
 
 ```css
 button {
-  background-color: red;
+    background-color: red;
 }
 ```
 
@@ -78,7 +78,7 @@ green-theme.css
 
 ```css
 button {
-  background-color: green;
+    background-color: green;
 }
 ```
 
@@ -95,8 +95,8 @@ This allows you to apply a specific theme file globally so all pages get it.
 **options.noSave** = _true_, this will cause it not to save this info for the getAppliedTheme to retrieve, this would typically used if you needed temporarily apply a theme.
 
 ```js
-var themes = require('nativescript-themes')
-themes.applyTheme('red-theme.css')
+var themes = require('nativescript-themes');
+themes.applyTheme('red-theme.css');
 ```
 
 ### theme.getAppliedTheme(<default_theme>);
@@ -104,12 +104,12 @@ themes.applyTheme('red-theme.css')
 This returns the last theme applied; if no theme has been applied it will use the default_theme.
 
 ```js
-var themes = require('nativescript-themes')
-var currentTheme = themes.getAppliedTheme('red-theme.css')
+var themes = require('nativescript-themes');
+var currentTheme = themes.getAppliedTheme('red-theme.css');
 if (currentTheme === 'red-theme.css') {
-  console.log('We are using the default red-theme!')
+    console.log('We are using the default red-theme!');
 } else {
-  console.log('We are using', currentTheme)
+    console.log('We are using', currentTheme);
 }
 ```
 
@@ -118,12 +118,12 @@ if (currentTheme === 'red-theme.css') {
 This function receives a string containing CSS and applies it. The `filename` is only for reference (no file will be actually loaded).
 
 ```js
-var themes = require('nativescript-themes')
-themes.applyThemeCss('page {background-color: black;}', 'default-theme.css')
+var themes = require('nativescript-themes');
+themes.applyThemeCss('page {background-color: black;}', 'default-theme.css');
 ```
 
 ## Tutorials
 
 Need some extra help getting started? Check out these tutorials for dealing with NativeScript UI themes in an iOS and Android application.
 
-- [Changing the UI Theme in a NativeScript Angular Application](https://www.thepolyglotdeveloper.com/2016/11/changing-a-nativescript-css-skin-at-runtime/)
+-   [Changing the UI Theme in a NativeScript Angular Application](https://www.thepolyglotdeveloper.com/2016/11/changing-a-nativescript-css-skin-at-runtime/)

--- a/src/README.md
+++ b/src/README.md
@@ -1,9 +1,8 @@
-[![npm](https://img.shields.io/npm/v/nativescript-themes.svg)](https://www.npmjs.com/package/nativescript-themes)
-[![npm](https://img.shields.io/npm/l/nativescript-themes.svg)](https://www.npmjs.com/package/nativescript-themes)
-[![npm](https://img.shields.io/npm/dt/nativescript-themes.svg?label=npm%20d%2fls)](https://www.npmjs.com/package/nativescript-themes)
+[![npm](https://img.shields.io/npm/v/nativescript-themes.svg)](https://www.npmjs.com/package/nativescript-themes) [![npm](https://img.shields.io/npm/l/nativescript-themes.svg)](https://www.npmjs.com/package/nativescript-themes) [![npm](https://img.shields.io/npm/dt/nativescript-themes.svg?label=npm%20d%2fls)](https://www.npmjs.com/package/nativescript-themes)
 
 # nativescript-themes
-A NativeScript plugin to deal with dynamically loading UI Themes 
+
+A NativeScript plugin to deal with dynamically loading UI Themes
 
 ## Installation
 
@@ -15,14 +14,14 @@ tns plugin add nativescript-themes@1.1.0
 
 tns plugin add nativescript-themes
 
-
 ## Status: BROKEN in NS 3 & 4
-Please note this plugin is currently broken do to some new issues in the actual NativeScript core modules.  Until they fix either:
+
+Please note this plugin is currently broken do to some new issues in the actual NativeScript core modules. Until they fix either:
+
 - [https://github.com/NativeScript/NativeScript/issues/5912](https://github.com/NativeScript/NativeScript/issues/5912)
 - [https://github.com/NativeScript/NativeScript/issues/5911](https://github.com/NativeScript/NativeScript/issues/5911)
 
-This plugin will be unable to work....   Please up vote those issues if you want to see this plugin work again...
-
+This plugin will be unable to work.... Please up vote those issues if you want to see this plugin work again...
 
 ## License
 
@@ -30,81 +29,101 @@ This is released under the MIT License, meaning you are free to include this in 
 
 I also do contract work; so if you have a module you want built for NativeScript (or any other software projects) feel free to contact me [nathan@master-technology.com](mailto://nathan@master-technology.com).
 
-[![Donate](https://img.shields.io/badge/Donate-PayPal-brightgreen.svg?style=plastic)](https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=HN8DDMWVGBNQL&lc=US&item_name=Nathanael%20Anderson&item_number=nativescript%2dthemes&no_note=1&no_shipping=1&currency_code=USD&bn=PP%2dDonationsBF%3ax%3aNonHosted)
-[![Patreon](https://img.shields.io/badge/Pledge-Patreon-brightgreen.svg?style=plastic)](https://www.patreon.com/NathanaelA)
-
+[![Donate](https://img.shields.io/badge/Donate-PayPal-brightgreen.svg?style=plastic)](https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=HN8DDMWVGBNQL&lc=US&item_name=Nathanael%20Anderson&item_number=nativescript%2dthemes&no_note=1&no_shipping=1&currency_code=USD&bn=PP%2dDonationsBF%3ax%3aNonHosted) [![Patreon](https://img.shields.io/badge/Pledge-Patreon-brightgreen.svg?style=plastic)](https://www.patreon.com/NathanaelA)
 
 ## Sample Snapshot
+
 ![Sample1](docs/themes.gif)
-
-
 
 ## Usage
 
 To use the module you just `require()` it:
 
 ```js
-var themes = require( "nativescript-themes" );
+var themes = require('nativescript-themes')
 ```
 
 ## Setup in App
+
 Modify your startup app.js
 
 ```js
-var themes = require('nativescript-themes');
-themes.applyTheme(themes.getAppliedTheme('red-theme.css'));
+var themes = require('nativescript-themes')
+themes.applyTheme(themes.getAppliedTheme('red-theme.css'))
 ```
-This will automatically apply the "red-theme.css" theme if no other theme has ever been chosen as the default theme. 
 
+This will automatically apply the "red-theme.css" theme if no other theme has ever been chosen as the default theme.
 
+You can also load a theme bundled by webpack using `applyThemeCss`:
+
+```js
+var themes = require('nativescript-themes')
+var cssText = require('~/assets/themes/dark.scss')
+themes.applyThemeCss(cssText, 'dark.scss')
+```
 
 ## You ask, how exactly does this help?
-This allows you to dynamically theme an application just by calling the theme system.  Your master app.css file is applied first, then the theme file and finally your page.css
+
+This allows you to dynamically theme an application just by calling the theme system. Your master app.css file is applied first, then the theme file and finally your page.css
 
 red-theme.css
+
 ```css
-Button {
+button {
   background-color: red;
 }
 ```
 
 green-theme.css
+
 ```css
-Button {
+button {
   background-color: green;
 }
 ```
 
 ## Demo
+
 Demo shows three sample themes, and shows how to load the last chosen theme at startup.
 
-
 ## Why use this?
+
 This allows you to apply a specific theme file globally so all pages get it.
 
-
 ### themes.applyTheme('cssFile', options);
+
 **options.noSave** = _true_, this will cause it not to save this info for the getAppliedTheme to retrieve, this would typically used if you needed temporarily apply a theme.
+
 ```js
-  var themes = require('nativescript-themes');
-  themes.applyTheme('red-theme.css');
+var themes = require('nativescript-themes')
+themes.applyTheme('red-theme.css')
 ```
 
-
 ### theme.getAppliedTheme(<default_theme>);
+
 This returns the last theme applied; if no theme has been applied it will use the default_theme.
+
 ```js
-  var themes = require('nativescript-themes');
-  var currentTheme = themes.getAppliedTheme('red-theme.css');
-  if (currentTheme === 'red-theme.css') {
-      console.log("We are using the default red-theme!")
-  } else {
-      console.log("We are using", currentTheme);
-  }
+var themes = require('nativescript-themes')
+var currentTheme = themes.getAppliedTheme('red-theme.css')
+if (currentTheme === 'red-theme.css') {
+  console.log('We are using the default red-theme!')
+} else {
+  console.log('We are using', currentTheme)
+}
+```
+
+### themes.applyThemeCss('textCss', 'filename');
+
+This function receives a string containing CSS and applies it. The `filename` is only for reference (no file will be actually loaded).
+
+```js
+var themes = require('nativescript-themes')
+themes.applyThemeCss('page {background-color: black;}', 'default-theme.css')
 ```
 
 ## Tutorials
 
-Need some extra help getting started?  Check out these tutorials for dealing with NativeScript UI themes in an iOS and Android application.
+Need some extra help getting started? Check out these tutorials for dealing with NativeScript UI themes in an iOS and Android application.
 
-* [Changing the UI Theme in a NativeScript Angular Application](https://www.thepolyglotdeveloper.com/2016/11/changing-a-nativescript-css-skin-at-runtime/)
+- [Changing the UI Theme in a NativeScript Angular Application](https://www.thepolyglotdeveloper.com/2016/11/changing-a-nativescript-css-skin-at-runtime/)

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,0 +1,48 @@
+{
+	"name": "nativescript-themes",
+	"version": "2.0.0",
+	"lockfileVersion": 1,
+	"requires": true,
+	"dependencies": {
+		"prettier": {
+			"version": "1.16.4",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-1.16.4.tgz",
+			"integrity": "sha512-ZzWuos7TI5CKUeQAtFd6Zhm2s6EpAD/ZLApIhsF9pRvRtM1RFo61dM/4MSRUA0SuLugA/zgrZD8m0BaY46Og7g==",
+			"dev": true
+		},
+		"tns-core-modules": {
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/tns-core-modules/-/tns-core-modules-5.3.1.tgz",
+			"integrity": "sha512-b1zBFr+LTxnUe+jxMqyfjHYXKqbECT/YNqtxmJpbma9P+gqPTfFJ1eFWU+yVNQVDIQhZ/Wy8P56H6cm99nmYoQ==",
+			"dev": true,
+			"requires": {
+				"tns-core-modules-widgets": "5.3.0",
+				"tslib": "^1.9.3"
+			}
+		},
+		"tns-core-modules-widgets": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/tns-core-modules-widgets/-/tns-core-modules-widgets-5.3.0.tgz",
+			"integrity": "sha512-mR8Pof0NhMRhPYcshQ54WyPrlbrqmTgrwxALtF1485fbCAHblz/2DqU7yGmTgC5LNdV7yhNeHYouoYg3TYOZbA==",
+			"dev": true
+		},
+		"tns-platform-declarations": {
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/tns-platform-declarations/-/tns-platform-declarations-5.3.1.tgz",
+			"integrity": "sha512-sTEx3eGOEqILzLTARIamuMlCL0fZ3REyVaCJ0n19Nq7OdjnQiTV6zGADl5yQ1mI4NLZVtAtLQgc90Qj9XYnMIw==",
+			"dev": true
+		},
+		"tslib": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+			"integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+			"dev": true
+		},
+		"typescript": {
+			"version": "3.1.6",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.6.tgz",
+			"integrity": "sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==",
+			"dev": true
+		}
+	}
+}

--- a/src/package.json
+++ b/src/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "nativescript-themes",
+  "name": "nativescript-themes-scss",
   "version": "2.0.0",
   "description": "A NativeScript plugin to deal with Themes in the Declarative UI ",
   "main": "themes.js",
   "nativescript": {
 	"platforms": {
-		"android": "4.2.0",
-		"ios": "4.2.0"
+		"android": "4.0.0",
+		"ios": "4.0.0"
 	},
 	"plugin": {
 	  "pan": "true",

--- a/src/package.json
+++ b/src/package.json
@@ -1,38 +1,62 @@
 {
-  "name": "nativescript-themes",
-  "version": "2.0.0",
-  "description": "A NativeScript plugin to deal with Themes in the Declarative UI ",
-  "main": "themes.js",
-  "nativescript": {
-	"platforms": {
-		"android": "4.0.0",
-		"ios": "4.0.0"
+	"name": "nativescript-themes",
+	"version": "2.0.0",
+	"description": "A NativeScript plugin to deal with Themes in the Declarative UI.",
+	"main": "themes.js",
+	"nativescript": {
+		"platforms": {
+			"android": "4.2.0",
+			"ios": "4.2.0"
+		},
+		"plugin": {
+			"pan": "true",
+			"core3": "false",
+			"core4": "true",
+			"category": "Interface"
+		}
 	},
-	"plugin": {
-	  "pan": "true",
-	  "core3": "false",
-	  "core4": "true",
-	  "category": "Interface"
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/nathanaela/nativescript-themes.git"
+	},
+	"keywords": [
+		"NativeScript",
+		"themes",
+		"ui",
+		"landscape",
+		"ios",
+		"android",
+		"colors"
+	],
+	"author": {
+		"name": "Nathanael Anderson",
+		"email": "nathan@master-technology.com"
+	},
+	"contributors": [
+		{
+			"email": "bradwaynemartin@gmail.com",
+			"url": "https://github.com/bradmartin",
+			"name": "Brad Martin"
+		},
+		{
+			"email": "tralves@gmail.com",
+			"url": "https://github.com/tralves",
+			"name": "Tiago Alves"
+		}
+	],
+	"license": {
+		"type": "MIT",
+		"url": "https://github.com/nathanaela/nativescript-themes/blob/master/LICENSE"
+	},
+	"bugs": {
+		"url": "https://github.com/nathanaela/nativescript-themes/issues"
+	},
+	"homepage": "https://github.com/nathanaela/nativescript-themes",
+	"readmeFilename": "README.md",
+	"devDependencies": {
+		"prettier": "~1.16.4",
+		"tns-core-modules": "~5.3.1",
+		"tns-platform-declarations": "~5.3.1",
+		"typescript": "~3.1.6"
 	}
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/nathanaela/nativescript-themes.git"
-  },
-  "keywords": [
-    "NativeScript", "themes", "ui", "landscape", "ios", "android", "colors"
-  ],
-  "author": {
-    "name": "Nathanael Anderson",
-    "email": "nathan@master-technology.com"
-  },
-  "license": {
-    "type": "MIT",
-    "url": "https://github.com/nathanaela/nativescript-themes/blob/master/LICENSE"
-  },
-  "bugs": {
-    "url": "https://github.com/nathanaela/nativescript-themes/issues"
-  },
-  "homepage": "https://github.com/nathanaela/nativescript-themes",
-  "readmeFilename": "README.md"
 }

--- a/src/package.json
+++ b/src/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "nativescript-themes-scss",
+  "name": "nativescript-themes",
   "version": "2.0.0",
   "description": "A NativeScript plugin to deal with Themes in the Declarative UI ",
   "main": "themes.js",

--- a/src/themes.js
+++ b/src/themes.js
@@ -43,7 +43,6 @@ Themes.prototype.getAppliedTheme = function(defaultTheme) {
 
 Themes.prototype.applyTheme = function(cssFile, options) {
     if (!cssFile) {
-        console.log('No Theme css file provided');
         return;
     }
     if (!application.hasLaunched()) {
@@ -90,15 +89,15 @@ function internalLoadCssFile(cssFile, path) {
         cssFileName = fs.path.join(path, cssFileName);
     }
 
-    var textCSS = '';
+    var textCss = '';
 
     // Load the new Selectors
     if (cssFileName && FSA.fileExists(cssFileName)) {
         var file = fs.File.fromPath(cssFileName);
-        textCSS = file.readTextSync();
+        textCss = file.readTextSync();
     }
 
-    internalLoadCss(textCSS, cssFileName);
+    internalLoadCss(textCss, cssFileName);
 }
 
 function internalLoadCss(textCss, cssFileName) {
@@ -112,9 +111,9 @@ function internalLoadCss(textCss, cssFileName) {
     // Remove old Selectors
     var changed = StyleScope.removeTaggedAdditionalCSS(_priorTheme);
 
-    if (textCSS) {
+    if (textCss) {
         // Add new Selectors
-        StyleScope.addTaggedAdditionalCSS(textCSS, cssFileName);
+        StyleScope.addTaggedAdditionalCSS(textCss, cssFileName);
 
         changed = true;
         _priorTheme = cssFileName;

--- a/src/themes.js
+++ b/src/themes.js
@@ -7,150 +7,153 @@
  * Any questions please feel free to email me or put a issue up on the github repo
  * Version 3.0.0                                      Nathan@master-technology.com
  *********************************************************************************/
+// @ts-check
+
 'use strict';
 
 /* jshint camelcase: false */
 /* global UIDevice, UIDeviceOrientation, getElementsByTagName, android */
 
-var fs = require('file-system');
-var fsa = require('file-system/file-system-access').FileSystemAccess;
-var frameCommon = require('ui/frame/frame-common');
-var appSettings = require('application-settings');
-var application = require('application');
-var StyleScope = require('ui/styling/style-scope');
+const fs = require('tns-core-modules/file-system');
+const fsa = require('tns-core-modules/file-system/file-system-access').FileSystemAccess;
+const frameCommon = require('tns-core-modules/ui/frame/frame-common');
+const appSettings = require('tns-core-modules/application-settings');
+const application = require('tns-core-modules/application');
+const StyleScope = require('tns-core-modules/ui/styling/style-scope');
+
+let _priorTheme = '!!NO_THEME_LOADED!!';
 
 // This allows some basic CSS to propogate properly from the frame; but not the localStyles CSS.  See bug NativeScript#5911 & #5912
-if (!frameCommon.FrameBase.prototype.eachChild) {
-    //	frameCommon.FrameBase.prototype.eachChild = frameCommon.FrameBase.prototype.eachChildView;
-}
+// if (!frameCommon.FrameBase.prototype.eachChild) {
+// 		frameCommon.FrameBase.prototype.eachChild = frameCommon.FrameBase.prototype.eachChildView;
+// }
 
-var Themes = function() {
-    this._curAppPath = fs.knownFolders.currentApp().path + '/';
+const Themes = function() {
+	this._curAppPath = fs.knownFolders.currentApp().path + '/';
 };
 
 Themes.prototype.getAppliedTheme = function(defaultTheme) {
-    defaultTheme = defaultTheme || '';
+	defaultTheme = defaultTheme || '';
 
-    if (appSettings.hasKey('__NS.themes')) {
-        var theme = appSettings.getString('__NS.themes', defaultTheme);
-        if (theme == null || theme === '') {
-            return defaultTheme;
-        }
-        return theme;
-    }
-    return defaultTheme;
+	if (appSettings.hasKey('__NS.themes')) {
+		const theme = appSettings.getString('__NS.themes', defaultTheme);
+		if (theme == null || theme === '') {
+			return defaultTheme;
+		}
+		return theme;
+	}
+	return defaultTheme;
 };
 
 Themes.prototype.applyTheme = function(cssFile, options) {
-    if (!cssFile) {
-        return;
-    }
-    if (!application.hasLaunched()) {
-        var self = this;
-        var applyTheme = function() {
-            internalLoadCssFile(cssFile, self._curAppPath);
-            if (!(options && options.noSave)) {
-                appSettings.setString('__NS.themes', cssFile);
-            }
-            application.off('loadAppCss', applyTheme);
-        };
+	if (!cssFile) {
+		return;
+	}
+	if (!application.hasLaunched()) {
+		const self = this;
+		const applyTheme = function() {
+			internalLoadCssFile(cssFile, self._curAppPath);
+			if (!(options && options.noSave)) {
+				appSettings.setString('__NS.themes', cssFile);
+			}
+			application.off('loadAppCss', applyTheme);
+		};
 
-        application.on('loadAppCss', applyTheme);
-        return;
-    }
+		application.on('loadAppCss', applyTheme);
+		return;
+	}
 
-    internalLoadCssFile(cssFile, this._curAppPath);
-    if (!(options && options.noSave)) {
-        appSettings.setString('__NS.themes', cssFile);
-    }
+	internalLoadCssFile(cssFile, this._curAppPath);
+	if (!(options && options.noSave)) {
+		appSettings.setString('__NS.themes', cssFile);
+	}
 };
 
 Themes.prototype.applyThemeCss = function(textCss, cssFileName) {
-    internalLoadCss(textCss, cssFileName);
+	internalLoadCss(textCss, cssFileName);
 };
 
-var _priorTheme = '!!NO_THEME_LOADED!!';
 /**
  * Set the  theme .css file
  * @param cssFile - css file to load
  * @param path - application path
  */
 function internalLoadCssFile(cssFile, path) {
-    var FSA = new fsa();
-    var cssFileName = cssFile;
+	const FSA = new fsa();
+	let cssFileName = cssFile;
 
-    if (cssFileName.startsWith('~/')) {
-        cssFileName = fs.path.join(path, cssFileName.replace('~/', ''));
-    } else if (cssFileName.startsWith('./')) {
-        cssFileName = cssFileName.substring(2);
-    }
+	if (cssFileName.startsWith('~/')) {
+		cssFileName = fs.path.join(path, cssFileName.replace('~/', ''));
+	} else if (cssFileName.startsWith('./')) {
+		cssFileName = cssFileName.substring(2);
+	}
 
-    if (!cssFileName.startsWith(path)) {
-        cssFileName = fs.path.join(path, cssFileName);
-    }
+	if (!cssFileName.startsWith(path)) {
+		cssFileName = fs.path.join(path, cssFileName);
+	}
 
-    var textCss = '';
+	let textCss = '';
 
-    // Load the new Selectors
-    if (cssFileName && FSA.fileExists(cssFileName)) {
-        var file = fs.File.fromPath(cssFileName);
-        textCss = file.readTextSync();
-    }
+	// Load the new Selectors
+	if (cssFileName && FSA.fileExists(cssFileName)) {
+		const file = fs.File.fromPath(cssFileName);
+		textCss = file.readTextSync();
+	}
 
-    internalLoadCss(textCss, cssFileName);
+	internalLoadCss(textCss, cssFileName);
 }
 
 function internalLoadCss(textCss, cssFileName) {
-    if (!frameCommon.topmost()) {
-        setTimeout(function() {
-            internalLoadCss(textCss, cssFileName);
-        }, 50);
-        return;
-    }
+	if (!frameCommon.topmost()) {
+		setTimeout(function() {
+			internalLoadCss(textCss, cssFileName);
+		}, 50);
+		return;
+	}
 
-    // Remove old Selectors
-    var changed = StyleScope.removeTaggedAdditionalCSS(_priorTheme);
+	// Remove old Selectors
+	let changed = StyleScope.removeTaggedAdditionalCSS(_priorTheme);
 
-    if (textCss) {
-        // Add new Selectors
-        StyleScope.addTaggedAdditionalCSS(textCss, cssFileName);
+	if (textCss) {
+		// Add new Selectors
+		StyleScope.addTaggedAdditionalCSS(textCss, cssFileName);
 
-        changed = true;
-        _priorTheme = cssFileName;
-    }
+		changed = true;
+		_priorTheme = cssFileName;
+	}
 
-    if (changed) {
-        var frame = frameCommon.topmost();
-        if (frame) {
-            if (frame._styleScope) {
-                frame._styleScope._localCssSelectorVersion++;
-                frame._styleScope.ensureSelectors();
-                frame._onCssStateChange();
-            }
-            var backStack = frame.backStack;
-            if (backStack) {
-                for (var i = 0; i < backStack.length; i++) {
-                    var page = backStack[i].resolvedPage;
-                    if (page) {
-                        //page._onCssStateChange();
-                        // I suspect this method is probably safer; but the above actually does work...
-                        page.on('navigatingTo', updatedCSSState);
-                    }
-                }
-            }
+	if (changed) {
+		const frame = frameCommon.topmost();
+		if (frame) {
+			if (frame._styleScope) {
+				frame._styleScope._localCssSelectorVersion++;
+				frame._styleScope.ensureSelectors();
+				frame._onCssStateChange();
+			}
+			const backStack = frame.backStack;
+			if (backStack) {
+				for (let i = 0; i < backStack.length; i++) {
+					const page = backStack[i].resolvedPage;
+					if (page) {
+						//page._onCssStateChange();
+						// I suspect this method is probably safer; but the above actually does work...
+						page.on('navigatingTo', updatedCSSState);
+					}
+				}
+			}
 
-            var page = frame.currentPage;
-            if (page) {
-                page._onCssStateChange();
-            }
-        }
-    }
+			const page = frame.currentPage;
+			if (page) {
+				page._onCssStateChange();
+			}
+		}
+	}
 }
 
 function updatedCSSState(args) {
-    var page = args.object;
-    page._onCssStateChange();
-    page.off('navigatingTo', updatedCSSState);
+	const page = args.object;
+	page._onCssStateChange();
+	page.off('navigatingTo', updatedCSSState);
 }
 
 // Export the theme system

--- a/src/themes.js
+++ b/src/themes.js
@@ -110,7 +110,7 @@ function internalLoadCss(textCss, cssFileName) {
     }
 
     // Remove old Selectors
-    var changed = StyleScope.removeTaggedAdditonalCSS(_priorTheme);
+    var changed = StyleScope.removeTaggedAdditionalCSS(_priorTheme);
 
     if (textCSS) {
         // Add new Selectors


### PR DESCRIPTION
This PR adds the function applyThemeCss that receives a string containing CSS and applies it.

The branch was created from master (the version not yet in npm).

I created the sample project ns-vue-theme-swap-sample. In this project, I implemented theme swapping with both the existing method applyTheme and the new method applyThemeCss to show that I didn't ruin the current functionality.

The file themes.js had both tabs and spaces, so I went ahead an prettyfied it... sorry...